### PR TITLE
Update AEAD computations

### DIFF
--- a/draft-omara-sframe.md
+++ b/draft-omara-sframe.md
@@ -75,9 +75,8 @@ This document proposes a new end-to-end encryption mechanism known as SFrame, sp
 | +---------------------------------------------------------------+ |
 |                                                                   |
 ++ Encrypted Portion*                      Authenticated Portion +--+
-
-                        SRTP packet format
 ~~~~~
+{: title="SRTP packet format"}
 
 # Terminology
 
@@ -183,7 +182,6 @@ Alice |                    +-----+------+                     |   Encrypted Pack
       |  +----------+      +------------+      +-----------+  |
       |                                                       |
       +-------------------------------------------------------+
-
 ~~~~~
 
 The E2EE keys used to encrypt the frame are exchanged out of band using a secure E2EE channel.
@@ -191,7 +189,6 @@ The E2EE keys used to encrypt the frame are exchanged out of band using a secure
 ## SFrame Format
 
 ~~~~~
-
   +------------+------------------------------------------+^+
   |S|LEN|X|KID |         Frame Counter                    | |
 +^+------------+------------------------------------------+ |
@@ -210,8 +207,6 @@ The E2EE keys used to encrypt the frame are exchanged out of band using a secure
 |                                                           |
 |                                                           |
 +----+Encrypted Portion            Authenticated Portion+---+
-
-
 ~~~~~
 
 ## SFrame Header
@@ -346,8 +341,8 @@ The encrypted payload is then passed to a generic RTP packetized to construct th
     |  payload 1/N  |      |               |     +---------------+   |
     |               |      |               |     |    auth tag   | <-+
     +---------------+      +---------------+     +---------------+
-                         Encryption flow
 ~~~~~
+{: title="Encryption flow" }
 
 ### Decryption
 The receiving clients buffer all packets that belongs to the same frame using the frame beginning and ending marks in the generic RTP frame header extension, and once all packets are available, it passes it to Frame for decryption. SFrame maintains multiple decryptor objects, one for each client in the call. Initially the client might not have the mapping between the incoming streams the user's keys, in this case SFrame tries all unmapped keys until it finds one that passes the authentication verification and use it to decrypt the frame. If the client has the mapping ready, it can push it down to SFrame later.
@@ -412,11 +407,8 @@ The authentication tags for the previous frames covered by the signature and the
     |                        |
     +-> Authenticated with   +-> Signed with
         Auth Tag N               Signature
-
-
-    Encrypted Frame with Signature
-
 ~~~~~
+{: title="Encrypted Frame with Signature" }
 
 Note that the authentication tag for the current frame will only authenticate the SFrame header and the encrypted payload, ant not the signature nor the previous frames's authentication tags (N-1 to N-M) used to calculate the signature.
 

--- a/draft-omara-sframe.md
+++ b/draft-omara-sframe.md
@@ -35,108 +35,6 @@ author:
     organization: CoSMo Software
     email: sergio.garcia.murillo@cosmosoftware.io
 
-
-informative:
-
-  MLSARCH:
-       title: "Messaging Layer Security Architecture"
-       date: 2020
-       author:
-         -  ins: E. Omara
-            name: Emad Omara
-            organization: Google
-            email: emadomara@google.com
-         -
-            ins: R. Barnes
-            name: Richard Barnes
-            organization: Cisco
-            email: rlb@ipv.sx
-         -
-	    ins: E. Rescorla
-            name: Eric Rescorla
-            organization: Mozilla
-            email: ekr@rtfm.com
-         -
-            ins: S. Inguva
-            name: Srinivas Inguva
-            organization: Twitter
-            email: singuva@twitter.com
-         -
-            ins: A. Kwon
-            name: Albert Kwon
-            organization: MIT
-            email: kwonal@mit.edu
-         -
-            ins: A. Duric
-            name: Alan Duric
-            organization: Wire
-            email: alan@wire.com
-
-
-  MLSPROTO:
-       title: "Messaging Layer Security Protocol"
-       date: 2020
-       author:
-         -  ins: R. Barnes
-            name: Richard Barnes
-            organization: Cisco
-            email: rlb@ipv.sx
-         -
-            ins: J. Millican
-            name: Jon Millican
-            organization: Facebook
-            email: jmillican@fb.com
-         -
-            ins: E. Omara
-            name: Emad Omara
-            organization: Google
-            email: emadomara@google.com
-         -
-            ins: K. Cohn-Gordon
-            name: Katriel Cohn-Gordon
-            organization: University of Oxford
-            email: me@katriel.co.uk
-         -
-            ins: R. Robert
-            name: Raphael Robert
-            organization: Wire
-            email: raphael@wire.com
-
-  PERC:
-       target: https://datatracker.ietf.org/doc/rfc8723/
-       title: PERC
-       date: 2020
-       author:
-       -
-          ins: C. Jennings
-          organization: Cisco Systems
-       -
-          ins: P. Jones
-          organization: Cisco Systems
-       -
-          ins: R. Barnes
-          organization: Cisco Systems
-       -
-          ins: A.B. Roach
-          organization: Mozilla
-
-
-  PERCLITE:
-       target: https://tools.ietf.org/html/draft-murillo-perc-lite-01
-       title: PERC-Lite
-       date: 2020
-       author:
-       -
-         ins: A. GOUAILLARD
-         name: Alexandre GOUAILLARD
-         organization: CoSMo Software
-         email: Alex.GOUAILLARD@cosmosoftware.io
-       -
-        ins: S. Murillo
-        name: Sergio Garcia Murillo
-        organization: CoSMo Software
-        email: sergio.garcia.murillo@cosmosoftware.io
-
 --- abstract
 
 This document describes the Secure Frame (SFrame) end-to-end encryption and authentication mechanism for media frames in a multiparty conference call, in which central media servers (SFUs) can access the media metadata needed to make forwarding decisions without having access to the actual media.
@@ -546,14 +444,14 @@ Each SFrame session uses a single ciphersuite that specifies the following primi
 o A hash function
 This is used for the Key derivation and frame hashes for signature. We recommend using SHA256 hash function.
 
-o An AEAD encryption algorithm [RFC5116]
+o An AEAD encryption algorithm {{!RFC5116}}
 While any AEAD algorithm can be used to encrypt the frame, we recommend using algorithms with safe MAC truncation like AES-CTR and HMAC to reduce the per-frame overhead. In this case we can use 80 bits MAC for video frames and 32 bits for audio frames similar to DTLS-SRTP cipher suites:
 
 1- AES_CM_128_HMAC_SHA256_80
 
 2- AES_CM_128_HMAC_SHA256_32
 
-o [Optional] A signature algorithm
+o (Optional) A signature algorithm
 If signature is supported, we recommend using ed25519
 
 
@@ -573,7 +471,7 @@ Keys must have a sequential id starting from 0 and incremented eery time a new k
 
 
 ## MLS-SFrame
-While any other E2EE KMS can be used with SFrame, there is a big advantage if it is used with {{MLSARCH}} which natively supports very large groups efficiently. When {{MLSPROTO}} is used, the endpoints keys (AKA Application secret) can be used directly for SFrame without the need to exchange separate key material. The application secret is rotated automatically by {{MLSPROTO}} when group membership changes.
+While any other E2EE KMS can be used with SFrame, there is a big advantage if it is used with {{?I-D.ietf-mls-architecture}} which natively supports very large groups efficiently. When {{?I-D.ietf-mls-protocol}} is used, the endpoints keys (AKA Application secret) can be used directly for SFrame without the need to exchange separate key material. The application secret is rotated automatically by {{?I-D.ietf-mls-protocol}} when group membership changes.
 
 
 # Media Considerations
@@ -653,14 +551,14 @@ Overhead bps = (Counter length + 1 + 4 ) * 8 * fps
 ~~~~~
 
 ## SFrame vs PERC-lite
-{{PERC}} has significant overhead over SFrame because the overhead is per packet, not per frame, and OHB (Original Header Block) which duplicates any RTP header/extension field modified by the SFU.
-{{PERCLITE}} {{https://mailarchive.ietf.org/arch/msg/perc/SB0qMHWz6EsDtz3yIEX0HWp5IEY/}} is slightly better because it doesn’t use the OHB anymore, however it still does per packet encryption using SRTP.
-Below the the overheard in {{PERCLITE}} implemented by Cosmos Software which uses extra 11 bytes per packet to preserve the PT, SEQ_NUM, TIME_STAMP and SSRC fields in addition to the extra MAC tag per packet.
+{{?RFC8723}} has significant overhead over SFrame because the overhead is per packet, not per frame, and OHB (Original Header Block) which duplicates any RTP header/extension field modified by the SFU.
+{{?I-D.murillo-perc-lite}} {{https://mailarchive.ietf.org/arch/msg/perc/SB0qMHWz6EsDtz3yIEX0HWp5IEY/}} is slightly better because it doesn’t use the OHB anymore, however it still does per packet encryption using SRTP.
+Below the the overheard in {{?I-D.murillo-perc-lite}} implemented by Cosmos Software which uses extra 11 bytes per packet to preserve the PT, SEQ_NUM, TIME_STAMP and SSRC fields in addition to the extra MAC tag per packet.
 
 OverheadPerPacket = 11 + MAC length
 Overhead bps = PacketPerSecond * OverHeadPerPacket * 8
 
-Similar to SFrame, we will assume the HBH authentication tag length will always be 4 bytes for audio and video even though it is not the case in this {{PERCLITE}} implementation
+Similar to SFrame, we will assume the HBH authentication tag length will always be 4 bytes for audio and video even though it is not the case in this {{?I-D.murillo-perc-lite}} implementation
 
 ### Audio
 ~~~~~

--- a/draft-omara-sframe.md
+++ b/draft-omara-sframe.md
@@ -47,8 +47,8 @@ The proposed mechanism differs from other approaches through its use of media fr
 Modern multi-party video call systems use Selective Forwarding Unit (SFU) servers to efficiently route RTP streams to call endpoints based on factors such as available bandwidth, desired video size, codec support, and other factors. In order for the SFU to work properly though, it needs to be able to access RTP metadata and RTCP feedback messages, which is not possible if all RTP/RTCP traffic is end-to-end encrypted.
 
 As such, two layers of encryptions and authentication are required:
-	1- Hop-by-hop (HBH) encryption of media, metadata, and feedback messages between the the endpoints and SFU
-	2- End-to-end (E2E) encryption of media between the endpoints
+  1- Hop-by-hop (HBH) encryption of media, metadata, and feedback messages between the the endpoints and SFU
+  2- End-to-end (E2E) encryption of media between the endpoints
 
 While DTLS-SRTP can be used as an efficient HBH mechanism, it is inherently point-to-point and therefore not suitable for a SFU context. In addition, given the various scenarios in which video calling occurs, minimizing the bandwidth overhead of end-to-end encryption is also an important goal.
 
@@ -511,16 +511,12 @@ Using three different audio frame durations
 100ms (10 packets/s)
 Up to 3 bytes frame counter (3.8 days of data for 20ms frame duration) and 4 bytes fixed MAC length.
 
-~~~~~
-+------------+-----------+-----------+----------+-----------+
 | Counter len| Packets   | Overhead  | Overhead | Overhead  |
 |            |           | bps@20ms  | bps@40ms | bps@100ms |
-+------------+-----------+-----------+----------+-----------+
+|:----------:|:---------:|:---------:|:--------:|:---------:|
 |          1 | 0-255     |      2400 |     1200 |       480 |
 |          2 | 255 - 65K |      2800 |     1400 |       560 |
 |          3 | 65K - 16M |      3200 |     1600 |       640 |
-+------------+--------- -+-----------+----------+-----------+
-~~~~~
 
 ## Video
 The per-stream overhead bits per second as calculated for the following video encodings:
@@ -530,17 +526,13 @@ The per-stream overhead bits per second as calculated for the following video en
 7.5fps@30Kbps (1 packet per frame)
 Overhead bps = (Counter length + 1 + 4 ) * 8 * fps
 
-~~~~~
-+------------+-----------+------------+------------+------------+
 | Counter len| Frames    | Overhead   | Overhead   | Overhead   |
 |            |           | bps@30fps  | bps@15fps  | bps@7.5fps |
-+------------+-----------+------------+------------+------------+
+|:----------:|:---------:|:----------:|:----------:|:----------:|
 |          1 | 0-255     |       1440 |       1440 |        720 |
 |          2 | 256 - 65K |       1680 |       1680 |        840 |
 |          3 | 56K - 16M |       1920 |       1920 |        960 |
 |          4 | 16M - 4B  |       2160 |       2160 |       1080 |
-+------------+-----------+------------+------------+------------+
-~~~~~
 
 ## SFrame vs PERC-lite
 {{?RFC8723}} has significant overhead over SFrame because the overhead is per packet, not per frame, and OHB (Original Header Block) which duplicates any RTP header/extension field modified by the SFU.
@@ -553,23 +545,17 @@ Overhead bps = PacketPerSecond * OverHeadPerPacket * 8
 Similar to SFrame, we will assume the HBH authentication tag length will always be 4 bytes for audio and video even though it is not the case in this {{?I-D.murillo-perc-lite}} implementation
 
 ### Audio
-~~~~~
-+-------------------+--------------------+--------------------+
+
 | Overhead bps@20ms | Overhead  bps@40ms | Overhead bps@100ms |
-+-------------------+--------------------+--------------------+
+|:-----------------:|:------------------:|:------------------:|
 |              6000 |               3000 |               1200 |
-+-------------------+--------------------+--------------------+
-~~~~~
 
 ### Video
-~~~~~
-+---------------------+----------------------+-----------------------+
+
 | Overhead  bps@30fps |  Overhead  bps@15fps |  Overhead  bps@7.5fps |
 |(4 packets per frame)| (2 packets per frame)| (1 packet per frame)  |
-+---------------------+----------------------+-----------------------+
+|:-------------------:|:--------------------:|:---------------------:|
 |               14400 |                 7200 |                  3600 |
-+---------------------+----------------------+-----------------------+
-~~~~~
 
 For a conference with a single incoming audio stream (@ 50 pps) and 4 incoming video streams (@200 Kbps), the savings in overhead is 34800 - 9600 = ~25 Kbps, or ~3%.
 


### PR DESCRIPTION
This PR revises the encryption procedures in a few ways:

* Ciphersuites for AES-GCM are now included
* The combination of AES-CM and SHA2 is spelled out, including an AAD length prefix to guard against confusion attacks
* We use the RFC 5116 AEAD interface (in particular, no separate auth tag)
* ... and as a result the tag truncation is internal to the AES-CM+SHA combination
* SFrame encryption now includes the encoded header as AAD

Depends on #51 