### PR TITLE
Clarify key selection

### DIFF
--- a/draft-omara-sframe.md
+++ b/draft-omara-sframe.md
@@ -563,7 +563,7 @@ def AEAD.Decrypt(key, nonce, aad, ct):
     raise Exception("Authentication Failure")
 
   return AES-CM.Decrypt(key, nonce, inner_ct)
-~~~~
+~~~~~
 
 <!-- OPEN ISSUE: Is there a pre-defined CTR+SHA construct we could borrow
 instead of inventing our own?  Alternatively, we might be able to use AES CCM


### PR DESCRIPTION
The current key selection scheme is ambiguous, and as a result insecure.  Relying on trial decryption is not a safe way to determine which key/nonce were used to produce a given ciphertext (see, e.g., https://eprint.iacr.org/2019/016.pdf).  

This PR simplifies the key selection scheme so that each KID specifies exactly one key.  This still allows senders to update keys unilaterally; they just need to update the KID when they do it.