### PR TITLE
Fix fencing error

### DIFF
--- a/draft-omara-sframe.md
+++ b/draft-omara-sframe.md
@@ -550,7 +550,7 @@ def AEAD.Decrypt(key, nonce, aad, ct):
     raise Exception("Authentication Failure")
 
   return AES-CM.Decrypt(key, nonce, inner_ct)
-~~~~
+~~~~~
 
 <!-- OPEN ISSUE: Is there a pre-defined CTR+SHA construct we could borrow
 instead of inventing our own?  Alternatively, we might be able to use AES CCM


### PR DESCRIPTION
One `~` was missing from a code fence, resulting in the remainder of the document being treated as code.