### PR TITLE
Update key management and define an initial MLS integration

### DIFF
--- a/draft-omara-sframe.md
+++ b/draft-omara-sframe.md
@@ -563,7 +563,7 @@ def AEAD.Decrypt(key, nonce, aad, ct):
     raise Exception("Authentication Failure")
 
   return AES-CM.Decrypt(key, nonce, inner_ct)
-~~~~
+~~~~~
 
 <!-- OPEN ISSUE: Is there a pre-defined CTR+SHA construct we could borrow
 instead of inventing our own?  Alternatively, we might be able to use AES CCM


### PR DESCRIPTION
This PR attempts to capture the spirit of the original key management provisions with a little more clarity about assumptions.  It also adds a more more explicit construction for connecting SFrame to MLS.