### PR TITLE
Add test vectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,14 @@ $ make
 
 This requires that you have the necessary software installed.  See
 [the instructions](https://github.com/martinthomson/i-d-template/blob/master/doc/SETUP.md).
+
+## Regenerating Test Vectors
+
+After a breaking change in the specification, the test vector script should be
+updated accordingly, and used to generate new test vectors.
+
+```sh
+$ cd test-vectors
+$ go run known-answer-test.go -json >../test-vectors.json
+$ go run knwon-answer-test.go -md >../test-vectors.md
+```

--- a/draft-omara-sframe.md
+++ b/draft-omara-sframe.md
@@ -35,6 +35,13 @@ author:
     organization: CoSMo Software
     email: sergio.garcia.murillo@cosmosoftware.io
 
+informative:
+  TestVectors:
+    title: "SFrame Test Vectors"
+    target: https://github.com/eomara/sframe/blob/master/test-vectors.json
+    date: 2021
+
+
 --- abstract
 
 This document describes the Secure Frame (SFrame) end-to-end encryption and authentication mechanism for media frames in a multiparty conference call, in which central media servers (SFUs) can access the media metadata needed to make forwarding decisions without having access to the actual media.
@@ -730,3 +737,30 @@ The cipher suites defined in this draft use short authentication tags for encryp
 
 # IANA Considerations
 This document makes no requests of IANA.
+
+# Test Vectors
+
+This section provides a set of test vectors that implementations can use to
+verify that they correctly implement SFrame encryption and decryption.  For each
+ciphersuite, we provide:
+
+* [in] The `base_key` value (hex encoded)
+* [out] The `secret`, `key`, and `salt` values derived from the `base_key` (hex encoded)
+* A plaintext value that is encrypted in the following encryption cases
+* A sequence of encryption cases, including:
+  * [in] The `KID` and `CTR` values to be included in the header
+  * [out] The resulting encoded header (hex encoded)
+  * [out] The nonce computed from the `salt` and `CTR` values
+  * The ciphertext resulting from encrypting the plaintext with these parameters
+    (hex encoded)
+
+An implementation should reproduce the output values given the input values.
+Encryption with the input values and the plaintext should produce the
+ciphertext.  Decryption with the input values and the ciphertext should produce
+the plaintext.
+
+Line breaks and whitespace within values are inserted to conform to the width
+requirements of the RFC format.  They should be removed before use.
+These test vectors are also available in JSON format at {{TestVectors}}.
+
+{::include test-vectors.md}

--- a/test-vectors.json
+++ b/test-vectors.json
@@ -1,0 +1,234 @@
+[
+  {
+    "cipher_suite": 1,
+    "base_key": "101112131415161718191a1b1c1d1e1f",
+    "key": "343d3290f5c0b936415bea9a43c6f5a2",
+    "salt": "42d662fbad5cd81eb3aad79a",
+    "plaintext": "46726f6d2068656176656e6c79206861726d6f6e79202f2f205468697320756e6976657273616c206672616d6520626567616e",
+    "encryptions": [
+      {
+        "kid": 7,
+        "ctr": 0,
+        "header": "1700",
+        "nonce": "42d662fbad5cd81eb3aad79a",
+        "ciphertext": "170065c67c6fb784631a7db1b589ffb62d75b78e28b0899e632fbbee3b944747a6382d75b6bd3788dc7b71b9295c7fb90b5098f7add14ef329"
+      },
+      {
+        "kid": 7,
+        "ctr": 1,
+        "header": "1701",
+        "nonce": "42d662fbad5cd81eb3aad79b",
+        "ciphertext": "1701ec742e98d667be810f153ff0d4dad7969f69b310aa7c6b9cb911e83af09b0f0a6d74772d8195c8c9dae3878fd1cb10edb4176d12e2387a"
+      },
+      {
+        "kid": 7,
+        "ctr": 2,
+        "header": "1702",
+        "nonce": "42d662fbad5cd81eb3aad798",
+        "ciphertext": "1702ac9b495d37a1e48c712ade5cba72df0bf90f24aa022a454cfb92d8b87cd54335fb6b9eeded6a5aa4e2643d7a09946646001d0a41b09557"
+      },
+      {
+        "kid": 15,
+        "ctr": 170,
+        "header": "190faa",
+        "nonce": "42d662fbad5cd81eb3aad730",
+        "ciphertext": "190faaeaa5adc70cae0d6ebd36805fa87d2351dd02c55c751cd351a7fdb7f0927b474eae3e800033e08100a440002da17579678b36dc275789d5"
+      },
+      {
+        "kid": 511,
+        "ctr": 170,
+        "header": "1a01ffaa",
+        "nonce": "42d662fbad5cd81eb3aad730",
+        "ciphertext": "1a01ffaaeaa5adc70cae0d6ebd36805fa87d2351dd02c55c751cd351a7fdb7f0927b474eae3e800033e08100a440002da17579678b36dc9bbe558b"
+      },
+      {
+        "kid": 511,
+        "ctr": 43690,
+        "header": "2a01ffaaaa",
+        "nonce": "42d662fbad5cd81eb3aa7d30",
+        "ciphertext": "2a01ffaaaa170500225053f1a044e51c4e91a6b783f69b1714fb31531d95d5b8dd7926c2d43405b4f32b9b49dd6e0aa5aba2427a94ff97f81dcd2826"
+      },
+      {
+        "kid": 72057594037927935,
+        "ctr": 72057594037927935,
+        "header": "7fffffffffffffffffffffffffffff",
+        "nonce": "42d662fbada327e14c552865",
+        "ciphertext": "7fffffffffffffffffffffffffffffdca3655d5117bc838d6f4382ca468a4f992ff77bfd1d2f4391be6b33e8fb638dc48aa82f57fd91430c714def0b2089c8bfb2ac9da92415"
+      }
+    ]
+  },
+  {
+    "cipher_suite": 2,
+    "base_key": "202122232425262728292a2b2c2d2e2f",
+    "key": "3fce747d505e46ec9b92d9f58ee7a5d4",
+    "salt": "77fbf5f1d82c73f6d2b353c9",
+    "plaintext": "46726f6d2068656176656e6c79206861726d6f6e79202f2f205468697320756e6976657273616c206672616d6520626567616e",
+    "encryptions": [
+      {
+        "kid": 7,
+        "ctr": 0,
+        "header": "1700",
+        "nonce": "77fbf5f1d82c73f6d2b353c9",
+        "ciphertext": "1700647513fce71aab7fed1e904fd9240343d77092c831f0d58fde0985a0f3e5ba4020e87a7b9c870b5f8f7f628d27690cc1e571e4d391da5fbf428433"
+      },
+      {
+        "kid": 7,
+        "ctr": 1,
+        "header": "1701",
+        "nonce": "77fbf5f1d82c73f6d2b353c8",
+        "ciphertext": "17019e1bdf713b0d4c02f3dbf50a72ea773286e7da38f3872cc734f3e1b1448aab5009b424e05495214f96d02e4e8f8da975cc808f40f67cafead7cffd"
+      },
+      {
+        "kid": 7,
+        "ctr": 2,
+        "header": "1702",
+        "nonce": "77fbf5f1d82c73f6d2b353cb",
+        "ciphertext": "170220ad36fd9191453ace2d36a175ad8a69c1f16b8613d14b4f7ef30c68bc5609e349df38155cc1544d7dbfa079e3faae3c7883b448e75047caafe05b"
+      },
+      {
+        "kid": 15,
+        "ctr": 170,
+        "header": "190faa",
+        "nonce": "77fbf5f1d82c73f6d2b35363",
+        "ciphertext": "190faadab9b284a4b9e3aea36b9cdcae4a58e141d3f0f52f240ef80a93dbb8d809ede01b05b2cace18a22fb39c032724481c5baa181d6b793458355b0f30"
+      },
+      {
+        "kid": 511,
+        "ctr": 170,
+        "header": "1a01ffaa",
+        "nonce": "77fbf5f1d82c73f6d2b35363",
+        "ciphertext": "1a01ffaadab9b284a4b9e3aea36b9cdcae4a58e141d3f0f52f240ef80a93dbb8d809ede01b05b2cace18a22fb39c032724481c5baa181dad5ad0f89a1cfb58"
+      },
+      {
+        "kid": 511,
+        "ctr": 43690,
+        "header": "2a01ffaaaa",
+        "nonce": "77fbf5f1d82c73f6d2b3f963",
+        "ciphertext": "2a01ffaaaae0f2384e4dc472cb92238b5b722159205c4481665484de66985f155071655ca4e9d1c998781f8c7d439f8d1eb6f6071cd80fd22f7e8846ba91036a"
+      },
+      {
+        "kid": 72057594037927935,
+        "ctr": 72057594037927935,
+        "header": "7fffffffffffffffffffffffffffff",
+        "nonce": "77fbf5f1d8d38c092d4cac36",
+        "ciphertext": "7fffffffffffffffffffffffffffff4b8c7429d7ee83eec5e53808b80555b1f80b1df9d97877575fa1c7fa35b6119c68ed6543020075959dcc4ca6900a7f9cf1d936b640bba41ca62f6c"
+      }
+    ]
+  },
+  {
+    "cipher_suite": 3,
+    "base_key": "303132333435363738393a3b3c3d3e3f",
+    "key": "2ea2e8163ff56c0613e6fa9f20a213da",
+    "salt": "a80478b3f6fba19983d540d5",
+    "plaintext": "46726f6d2068656176656e6c79206861726d6f6e79202f2f205468697320756e6976657273616c206672616d6520626567616e",
+    "encryptions": [
+      {
+        "kid": 7,
+        "ctr": 0,
+        "header": "1700",
+        "nonce": "a80478b3f6fba19983d540d5",
+        "ciphertext": "17000e426255e47ed70dd7d15d69d759bf459032ca15f5e8b2a91e7d348aa7c186d403f620801c495b1717a35097411aa97cbb140671eb3b49ac3775926db74d57b91e8e6c"
+      },
+      {
+        "kid": 7,
+        "ctr": 1,
+        "header": "1701",
+        "nonce": "a80478b3f6fba19983d540d4",
+        "ciphertext": "170103bbafa34ada8a6b9f2066bc34a1959d87384c9f4b1ce34fed58e938bde143393910b1aeb55b48d91d5b0db3ea67e3d0e02b843afd41630c940b1948e72dd45396a43a"
+      },
+      {
+        "kid": 7,
+        "ctr": 2,
+        "header": "1702",
+        "nonce": "a80478b3f6fba19983d540d7",
+        "ciphertext": "170258d58adebd8bf6f3cc0c1fcacf34ba4d7a763b2683fe302a57f1be7f2a274bf81b2236995fec1203cadb146cd402e1c52d5e6a10989dfe0f4116da1ee4c2fad0d21f8f"
+      },
+      {
+        "kid": 15,
+        "ctr": 170,
+        "header": "190faa",
+        "nonce": "a80478b3f6fba19983d5407f",
+        "ciphertext": "190faad0b1743bf5248f90869c9456366d55724d16bbe08060875815565e90b114f9ccbdba192422b33848a1ae1e3bd266a001b2f5bb727112772e0072ea8679ca1850cf11d8"
+      },
+      {
+        "kid": 511,
+        "ctr": 170,
+        "header": "1a01ffaa",
+        "nonce": "a80478b3f6fba19983d5407f",
+        "ciphertext": "1a01ffaad0b1743bf5248f90869c9456366d55724d16bbe08060875815565e90b114f9ccbdba192422b33848a1ae1e3bd266a001b2f5bbc9c63bd3973c19bd57127f565380ed4a"
+      },
+      {
+        "kid": 511,
+        "ctr": 43690,
+        "header": "2a01ffaaaa",
+        "nonce": "a80478b3f6fba19983d5ea7f",
+        "ciphertext": "2a01ffaaaa9de65e21e4f1ca2247b87943c03c5cb7b182090e93d508dcfb76e08174c6397356e682d2eaddabc0b3c1018d2c13c3570f61c1beaab805f27b565e1329a823a7a649b6"
+      },
+      {
+        "kid": 72057594037927935,
+        "ctr": 72057594037927935,
+        "header": "7fffffffffffffffffffffffffffff",
+        "nonce": "a80478b3f6045e667c2abf2a",
+        "ciphertext": "7fffffffffffffffffffffffffffff09981bdcdad80e380b6f74cf6afdbce946839bedadd57578bfcd809dbcea535546cc24660613d2761adea852155785011e633534f4ecc3b8257c8d34321c27854a1422"
+      }
+    ]
+  },
+  {
+    "cipher_suite": 4,
+    "base_key": "404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f",
+    "key": "436774b0b5ae45633d96547f8f3cb06c8e6628eff2e4255b5c4d77e721aa3355",
+    "salt": "31ed26f90a072e6aee646298",
+    "plaintext": "46726f6d2068656176656e6c79206861726d6f6e79202f2f205468697320756e6976657273616c206672616d6520626567616e",
+    "encryptions": [
+      {
+        "kid": 7,
+        "ctr": 0,
+        "header": "1700",
+        "nonce": "31ed26f90a072e6aee646298",
+        "ciphertext": "1700f3e297c1e95207710bd31ccc4ba396fbef7b257440bde638ff0f3c8911540136df61b26220249d6c432c245ae8d55ef45bfccf32530a15aeaaf313a03838e51bd45652"
+      },
+      {
+        "kid": 7,
+        "ctr": 1,
+        "header": "1701",
+        "nonce": "31ed26f90a072e6aee646299",
+        "ciphertext": "170193268b0bf030071bff443bb6b4471bdfb1cc81bc9625f4697b0336ff4665d15f152f02169448d8a967fb06359a87d2145398de0ce3fbe257b0992a3da1537590459f3c"
+      },
+      {
+        "kid": 7,
+        "ctr": 2,
+        "header": "1702",
+        "nonce": "31ed26f90a072e6aee64629a",
+        "ciphertext": "1702649691ba27c4c01a41280fba4657c03fa7fe21c8f5c862e9094227c3ca3ec0d9468b1a2cb060ff0978f25a24e6b106f5a6e1053c1b8f5fce794d88a0e4818c081e18ea"
+      },
+      {
+        "kid": 15,
+        "ctr": 170,
+        "header": "190faa",
+        "nonce": "31ed26f90a072e6aee646232",
+        "ciphertext": "190faa2858c10b5ddd231c1f26819490521678603a050448d563c503b1fd890d02ead01d754f074ecb6f32da9b2f3859f380b4f47d4edd1e15f42f9a2d7ecfac99067e238321"
+      },
+      {
+        "kid": 511,
+        "ctr": 170,
+        "header": "1a01ffaa",
+        "nonce": "31ed26f90a072e6aee646232",
+        "ciphertext": "1a01ffaa2858c10b5ddd231c1f26819490521678603a050448d563c503b1fd890d02ead01d754f074ecb6f32da9b2f3859f380b4f47d4e3bf7040eb10ec25b8126b2ce7b1d9d31"
+      },
+      {
+        "kid": 511,
+        "ctr": 43690,
+        "header": "2a01ffaaaa",
+        "nonce": "31ed26f90a072e6aee64c832",
+        "ciphertext": "2a01ffaaaad9bc6a258a07d210a814d545eca70321c0e87498ada6e5c708b7ead162ffcf4fbaba1eb82650590a87122b4d95fe36bd88b278812166d26e046ed0a530b7ee232ee0f2"
+      },
+      {
+        "kid": 72057594037927935,
+        "ctr": 72057594037927935,
+        "header": "7fffffffffffffffffffffffffffff",
+        "nonce": "31ed26f90af8d195119b9d67",
+        "ciphertext": "7fffffffffffffffffffffffffffffaf480d4779ce0c02b5137ee6a61e026c04ac999cb0c97319feceeb258d58df23bce14979e5c67a431777b34498062e72f939ca42ec84ffbc7b50eff923f515a2df760c"
+      }
+    ]
+  }
+]

--- a/test-vectors.md
+++ b/test-vectors.md
@@ -1,0 +1,380 @@
+## AES_CM_128_HMAC_SHA256_4
+
+~~~
+CipherSuite:    0x01
+Base Key:       101112131415161718191a1b1c1d1e1f
+Key:            343d3290f5c0b936415bea9a43c6f5a2
+Salt:           42d662fbad5cd81eb3aad79a
+Plaintext:      46726f6d2068656176656e6c79206861
+                726d6f6e79202f2f205468697320756e
+                6976657273616c206672616d65206265
+                67616e
+~~~
+
+~~~
+KID:            0x7
+CTR:            0x0
+Header:         1700
+Nonce:          42d662fbad5cd81eb3aad79a
+Ciphertext:     170065c67c6fb784631a7db1b589ffb6
+                2d75b78e28b0899e632fbbee3b944747
+                a6382d75b6bd3788dc7b71b9295c7fb9
+                0b5098f7add14ef329
+~~~
+
+~~~
+KID:            0x7
+CTR:            0x1
+Header:         1701
+Nonce:          42d662fbad5cd81eb3aad79b
+Ciphertext:     1701ec742e98d667be810f153ff0d4da
+                d7969f69b310aa7c6b9cb911e83af09b
+                0f0a6d74772d8195c8c9dae3878fd1cb
+                10edb4176d12e2387a
+~~~
+
+~~~
+KID:            0x7
+CTR:            0x2
+Header:         1702
+Nonce:          42d662fbad5cd81eb3aad798
+Ciphertext:     1702ac9b495d37a1e48c712ade5cba72
+                df0bf90f24aa022a454cfb92d8b87cd5
+                4335fb6b9eeded6a5aa4e2643d7a0994
+                6646001d0a41b09557
+~~~
+
+~~~
+KID:            0xf
+CTR:            0xaa
+Header:         190faa
+Nonce:          42d662fbad5cd81eb3aad730
+Ciphertext:     190faaeaa5adc70cae0d6ebd36805fa8
+                7d2351dd02c55c751cd351a7fdb7f092
+                7b474eae3e800033e08100a440002da1
+                7579678b36dc275789d5
+~~~
+
+~~~
+KID:            0x1ff
+CTR:            0xaa
+Header:         1a01ffaa
+Nonce:          42d662fbad5cd81eb3aad730
+Ciphertext:     1a01ffaaeaa5adc70cae0d6ebd36805f
+                a87d2351dd02c55c751cd351a7fdb7f0
+                927b474eae3e800033e08100a440002d
+                a17579678b36dc9bbe558b
+~~~
+
+~~~
+KID:            0x1ff
+CTR:            0xaaaa
+Header:         2a01ffaaaa
+Nonce:          42d662fbad5cd81eb3aa7d30
+Ciphertext:     2a01ffaaaa170500225053f1a044e51c
+                4e91a6b783f69b1714fb31531d95d5b8
+                dd7926c2d43405b4f32b9b49dd6e0aa5
+                aba2427a94ff97f81dcd2826
+~~~
+
+~~~
+KID:            0xffffffffffffff
+CTR:            0xffffffffffffff
+Header:         7fffffffffffffffffffffffffffff
+Nonce:          42d662fbada327e14c552865
+Ciphertext:     7fffffffffffffffffffffffffffffdc
+                a3655d5117bc838d6f4382ca468a4f99
+                2ff77bfd1d2f4391be6b33e8fb638dc4
+                8aa82f57fd91430c714def0b2089c8bf
+                b2ac9da92415
+~~~
+
+## AES_CM_128_HMAC_SHA256_8
+
+~~~
+CipherSuite:    0x02
+Base Key:       202122232425262728292a2b2c2d2e2f
+Key:            3fce747d505e46ec9b92d9f58ee7a5d4
+Salt:           77fbf5f1d82c73f6d2b353c9
+Plaintext:      46726f6d2068656176656e6c79206861
+                726d6f6e79202f2f205468697320756e
+                6976657273616c206672616d65206265
+                67616e
+~~~
+
+~~~
+KID:            0x7
+CTR:            0x0
+Header:         1700
+Nonce:          77fbf5f1d82c73f6d2b353c9
+Ciphertext:     1700647513fce71aab7fed1e904fd924
+                0343d77092c831f0d58fde0985a0f3e5
+                ba4020e87a7b9c870b5f8f7f628d2769
+                0cc1e571e4d391da5fbf428433
+~~~
+
+~~~
+KID:            0x7
+CTR:            0x1
+Header:         1701
+Nonce:          77fbf5f1d82c73f6d2b353c8
+Ciphertext:     17019e1bdf713b0d4c02f3dbf50a72ea
+                773286e7da38f3872cc734f3e1b1448a
+                ab5009b424e05495214f96d02e4e8f8d
+                a975cc808f40f67cafead7cffd
+~~~
+
+~~~
+KID:            0x7
+CTR:            0x2
+Header:         1702
+Nonce:          77fbf5f1d82c73f6d2b353cb
+Ciphertext:     170220ad36fd9191453ace2d36a175ad
+                8a69c1f16b8613d14b4f7ef30c68bc56
+                09e349df38155cc1544d7dbfa079e3fa
+                ae3c7883b448e75047caafe05b
+~~~
+
+~~~
+KID:            0xf
+CTR:            0xaa
+Header:         190faa
+Nonce:          77fbf5f1d82c73f6d2b35363
+Ciphertext:     190faadab9b284a4b9e3aea36b9cdcae
+                4a58e141d3f0f52f240ef80a93dbb8d8
+                09ede01b05b2cace18a22fb39c032724
+                481c5baa181d6b793458355b0f30
+~~~
+
+~~~
+KID:            0x1ff
+CTR:            0xaa
+Header:         1a01ffaa
+Nonce:          77fbf5f1d82c73f6d2b35363
+Ciphertext:     1a01ffaadab9b284a4b9e3aea36b9cdc
+                ae4a58e141d3f0f52f240ef80a93dbb8
+                d809ede01b05b2cace18a22fb39c0327
+                24481c5baa181dad5ad0f89a1cfb58
+~~~
+
+~~~
+KID:            0x1ff
+CTR:            0xaaaa
+Header:         2a01ffaaaa
+Nonce:          77fbf5f1d82c73f6d2b3f963
+Ciphertext:     2a01ffaaaae0f2384e4dc472cb92238b
+                5b722159205c4481665484de66985f15
+                5071655ca4e9d1c998781f8c7d439f8d
+                1eb6f6071cd80fd22f7e8846ba91036a
+~~~
+
+~~~
+KID:            0xffffffffffffff
+CTR:            0xffffffffffffff
+Header:         7fffffffffffffffffffffffffffff
+Nonce:          77fbf5f1d8d38c092d4cac36
+Ciphertext:     7fffffffffffffffffffffffffffff4b
+                8c7429d7ee83eec5e53808b80555b1f8
+                0b1df9d97877575fa1c7fa35b6119c68
+                ed6543020075959dcc4ca6900a7f9cf1
+                d936b640bba41ca62f6c
+~~~
+
+## AES_GCM_128_SHA256
+
+~~~
+CipherSuite:    0x03
+Base Key:       303132333435363738393a3b3c3d3e3f
+Key:            2ea2e8163ff56c0613e6fa9f20a213da
+Salt:           a80478b3f6fba19983d540d5
+Plaintext:      46726f6d2068656176656e6c79206861
+                726d6f6e79202f2f205468697320756e
+                6976657273616c206672616d65206265
+                67616e
+~~~
+
+~~~
+KID:            0x7
+CTR:            0x0
+Header:         1700
+Nonce:          a80478b3f6fba19983d540d5
+Ciphertext:     17000e426255e47ed70dd7d15d69d759
+                bf459032ca15f5e8b2a91e7d348aa7c1
+                86d403f620801c495b1717a35097411a
+                a97cbb140671eb3b49ac3775926db74d
+                57b91e8e6c
+~~~
+
+~~~
+KID:            0x7
+CTR:            0x1
+Header:         1701
+Nonce:          a80478b3f6fba19983d540d4
+Ciphertext:     170103bbafa34ada8a6b9f2066bc34a1
+                959d87384c9f4b1ce34fed58e938bde1
+                43393910b1aeb55b48d91d5b0db3ea67
+                e3d0e02b843afd41630c940b1948e72d
+                d45396a43a
+~~~
+
+~~~
+KID:            0x7
+CTR:            0x2
+Header:         1702
+Nonce:          a80478b3f6fba19983d540d7
+Ciphertext:     170258d58adebd8bf6f3cc0c1fcacf34
+                ba4d7a763b2683fe302a57f1be7f2a27
+                4bf81b2236995fec1203cadb146cd402
+                e1c52d5e6a10989dfe0f4116da1ee4c2
+                fad0d21f8f
+~~~
+
+~~~
+KID:            0xf
+CTR:            0xaa
+Header:         190faa
+Nonce:          a80478b3f6fba19983d5407f
+Ciphertext:     190faad0b1743bf5248f90869c945636
+                6d55724d16bbe08060875815565e90b1
+                14f9ccbdba192422b33848a1ae1e3bd2
+                66a001b2f5bb727112772e0072ea8679
+                ca1850cf11d8
+~~~
+
+~~~
+KID:            0x1ff
+CTR:            0xaa
+Header:         1a01ffaa
+Nonce:          a80478b3f6fba19983d5407f
+Ciphertext:     1a01ffaad0b1743bf5248f90869c9456
+                366d55724d16bbe08060875815565e90
+                b114f9ccbdba192422b33848a1ae1e3b
+                d266a001b2f5bbc9c63bd3973c19bd57
+                127f565380ed4a
+~~~
+
+~~~
+KID:            0x1ff
+CTR:            0xaaaa
+Header:         2a01ffaaaa
+Nonce:          a80478b3f6fba19983d5ea7f
+Ciphertext:     2a01ffaaaa9de65e21e4f1ca2247b879
+                43c03c5cb7b182090e93d508dcfb76e0
+                8174c6397356e682d2eaddabc0b3c101
+                8d2c13c3570f61c1beaab805f27b565e
+                1329a823a7a649b6
+~~~
+
+~~~
+KID:            0xffffffffffffff
+CTR:            0xffffffffffffff
+Header:         7fffffffffffffffffffffffffffff
+Nonce:          a80478b3f6045e667c2abf2a
+Ciphertext:     7fffffffffffffffffffffffffffff09
+                981bdcdad80e380b6f74cf6afdbce946
+                839bedadd57578bfcd809dbcea535546
+                cc24660613d2761adea852155785011e
+                633534f4ecc3b8257c8d34321c27854a
+                1422
+~~~
+
+## AES_GCM_256_SHA512
+
+~~~
+CipherSuite:    0x04
+Base Key:       404142434445464748494a4b4c4d4e4f
+                505152535455565758595a5b5c5d5e5f
+Key:            436774b0b5ae45633d96547f8f3cb06c
+                8e6628eff2e4255b5c4d77e721aa3355
+Salt:           31ed26f90a072e6aee646298
+Plaintext:      46726f6d2068656176656e6c79206861
+                726d6f6e79202f2f205468697320756e
+                6976657273616c206672616d65206265
+                67616e
+~~~
+
+~~~
+KID:            0x7
+CTR:            0x0
+Header:         1700
+Nonce:          31ed26f90a072e6aee646298
+Ciphertext:     1700f3e297c1e95207710bd31ccc4ba3
+                96fbef7b257440bde638ff0f3c891154
+                0136df61b26220249d6c432c245ae8d5
+                5ef45bfccf32530a15aeaaf313a03838
+                e51bd45652
+~~~
+
+~~~
+KID:            0x7
+CTR:            0x1
+Header:         1701
+Nonce:          31ed26f90a072e6aee646299
+Ciphertext:     170193268b0bf030071bff443bb6b447
+                1bdfb1cc81bc9625f4697b0336ff4665
+                d15f152f02169448d8a967fb06359a87
+                d2145398de0ce3fbe257b0992a3da153
+                7590459f3c
+~~~
+
+~~~
+KID:            0x7
+CTR:            0x2
+Header:         1702
+Nonce:          31ed26f90a072e6aee64629a
+Ciphertext:     1702649691ba27c4c01a41280fba4657
+                c03fa7fe21c8f5c862e9094227c3ca3e
+                c0d9468b1a2cb060ff0978f25a24e6b1
+                06f5a6e1053c1b8f5fce794d88a0e481
+                8c081e18ea
+~~~
+
+~~~
+KID:            0xf
+CTR:            0xaa
+Header:         190faa
+Nonce:          31ed26f90a072e6aee646232
+Ciphertext:     190faa2858c10b5ddd231c1f26819490
+                521678603a050448d563c503b1fd890d
+                02ead01d754f074ecb6f32da9b2f3859
+                f380b4f47d4edd1e15f42f9a2d7ecfac
+                99067e238321
+~~~
+
+~~~
+KID:            0x1ff
+CTR:            0xaa
+Header:         1a01ffaa
+Nonce:          31ed26f90a072e6aee646232
+Ciphertext:     1a01ffaa2858c10b5ddd231c1f268194
+                90521678603a050448d563c503b1fd89
+                0d02ead01d754f074ecb6f32da9b2f38
+                59f380b4f47d4e3bf7040eb10ec25b81
+                26b2ce7b1d9d31
+~~~
+
+~~~
+KID:            0x1ff
+CTR:            0xaaaa
+Header:         2a01ffaaaa
+Nonce:          31ed26f90a072e6aee64c832
+Ciphertext:     2a01ffaaaad9bc6a258a07d210a814d5
+                45eca70321c0e87498ada6e5c708b7ea
+                d162ffcf4fbaba1eb82650590a87122b
+                4d95fe36bd88b278812166d26e046ed0
+                a530b7ee232ee0f2
+~~~
+
+~~~
+KID:            0xffffffffffffff
+CTR:            0xffffffffffffff
+Header:         7fffffffffffffffffffffffffffff
+Nonce:          31ed26f90af8d195119b9d67
+Ciphertext:     7fffffffffffffffffffffffffffffaf
+                480d4779ce0c02b5137ee6a61e026c04
+                ac999cb0c97319feceeb258d58df23bc
+                e14979e5c67a431777b34498062e72f9
+                39ca42ec84ffbc7b50eff923f515a2df
+                760c
+~~~
+

--- a/test-vectors/go.mod
+++ b/test-vectors/go.mod
@@ -1,0 +1,5 @@
+module main
+
+go 1.16
+
+require golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2

--- a/test-vectors/go.sum
+++ b/test-vectors/go.sum
@@ -1,0 +1,7 @@
+golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 h1:It14KIkyBFYkHkwZ7k45minvA9aorojkyjGk9KJ5B/w=
+golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/test-vectors/known-answer-test.go
+++ b/test-vectors/known-answer-test.go
@@ -1,0 +1,441 @@
+package main
+
+import (
+	"crypto"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"strings"
+
+	_ "crypto/sha256"
+	_ "crypto/sha512"
+
+	"golang.org/x/crypto/hkdf"
+)
+
+///
+/// Cipher definitions
+///
+func chk(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+type CipherSuite struct {
+	ID      uint16
+	Name    string
+	Nk      int
+	Nn      int
+	Hash    crypto.Hash
+	NewAEAD func(key []byte) cipher.AEAD
+}
+
+func newGCM(key []byte) cipher.AEAD {
+	block, err := aes.NewCipher(key)
+	chk(err)
+
+	gcm, err := cipher.NewGCM(block)
+	chk(err)
+
+	return gcm
+}
+
+type AESCTRHMAC struct {
+	Block   cipher.Block
+	AuthKey []byte
+	Hash    crypto.Hash
+	TagSize int
+}
+
+func newAESCTRHMAC(key []byte, hash crypto.Hash, encSize, tagSize int) AESCTRHMAC {
+	secret := hkdf.Extract(hash.New, key, []byte("SFrame10 AES CM AEAD"))
+
+	encKey := make([]byte, encSize)
+	hkdf.Expand(hash.New, secret, []byte("enc")).Read(encKey)
+
+	authKey := make([]byte, hash.Size())
+	hkdf.Expand(hash.New, secret, []byte("auth")).Read(authKey)
+
+	block, err := aes.NewCipher(encKey)
+	chk(err)
+
+	return AESCTRHMAC{block, authKey, hash, tagSize}
+}
+
+func (ctr AESCTRHMAC) NonceSize() int {
+	return 12
+}
+
+func (ctr AESCTRHMAC) Overhead() int {
+	return ctr.TagSize
+}
+
+func (ctr AESCTRHMAC) crypt(nonce, pt []byte) []byte {
+	iv := append(nonce, []byte{0, 0, 0, 0}...)
+	stream := cipher.NewCTR(ctr.Block, iv)
+
+	ct := make([]byte, len(pt))
+	stream.XORKeyStream(ct, pt)
+	return ct
+}
+
+func (ctr AESCTRHMAC) tag(nonce, aad, ct []byte) []byte {
+	h := hmac.New(ctr.Hash.New, ctr.AuthKey)
+	binary.Write(h, binary.BigEndian, uint64(len(aad)))
+	binary.Write(h, binary.BigEndian, uint64(len(ct)))
+	h.Write(nonce)
+	h.Write(aad)
+	h.Write(ct)
+	return h.Sum(nil)[:ctr.TagSize]
+}
+
+func (ctr AESCTRHMAC) Seal(dst, nonce, plaintext, additionalData []byte) []byte {
+	ciphertext := ctr.crypt(nonce, plaintext)
+	tag := ctr.tag(nonce, additionalData, ciphertext)
+	return append(ciphertext, tag...)
+}
+
+func (ctr AESCTRHMAC) Open(dst, nonce, ciphertext, additionalData []byte) ([]byte, error) {
+	cut := len(ciphertext) - ctr.TagSize
+	innerCiphertext, tag := ciphertext[:cut], ciphertext[cut:]
+
+	computedTag := ctr.tag(nonce, additionalData, innerCiphertext)
+	if !hmac.Equal(computedTag, tag) {
+		return nil, fmt.Errorf("Authentication failure")
+	}
+
+	plaintext := ctr.crypt(nonce, innerCiphertext)
+	return plaintext, nil
+}
+
+func makeAESCTRHMAC(hash crypto.Hash, encSize, tagSize int) func(key []byte) cipher.AEAD {
+	return func(key []byte) cipher.AEAD {
+		return newAESCTRHMAC(key, hash, encSize, tagSize)
+	}
+}
+
+var (
+	AES_CM_128_HMAC_SHA256_4 = CipherSuite{
+		ID:      0x0001,
+		Name:    "AES_CM_128_HMAC_SHA256_4",
+		Nk:      16,
+		Nn:      12,
+		Hash:    crypto.SHA256,
+		NewAEAD: makeAESCTRHMAC(crypto.SHA256, 16, 4),
+	}
+	AES_CM_128_HMAC_SHA256_8 = CipherSuite{
+		ID:      0x0002,
+		Name:    "AES_CM_128_HMAC_SHA256_8",
+		Nk:      16,
+		Nn:      12,
+		Hash:    crypto.SHA256,
+		NewAEAD: makeAESCTRHMAC(crypto.SHA256, 16, 8),
+	}
+	AES_GCM_128_SHA256 = CipherSuite{
+		ID:      0x0003,
+		Name:    "AES_GCM_128_SHA256",
+		Nk:      16,
+		Nn:      12,
+		Hash:    crypto.SHA256,
+		NewAEAD: newGCM,
+	}
+	AES_GCM_256_SHA512 = CipherSuite{
+		ID:      0x0004,
+		Name:    "AES_GCM_256_SHA512",
+		Nk:      32,
+		Nn:      12,
+		Hash:    crypto.SHA512,
+		NewAEAD: newGCM,
+	}
+)
+
+func (suite CipherSuite) Extract(ikm, salt []byte) []byte {
+	return hkdf.Extract(suite.Hash.New, ikm, salt)
+}
+
+func (suite CipherSuite) Expand(prk, info []byte, size int) []byte {
+	out := make([]byte, size)
+	r := hkdf.Expand(suite.Hash.New, prk, info)
+	r.Read(out)
+	return out
+}
+
+func (suite CipherSuite) MarshalJSON() ([]byte, error) {
+	return json.Marshal(suite.ID)
+}
+
+///
+/// Test vector format
+///
+
+type HexData []byte
+
+func (hd HexData) MarshalJSON() ([]byte, error) {
+	hs := hex.EncodeToString(hd)
+	return json.Marshal(hs)
+}
+
+type Encryption struct {
+	KID        uint64  `json:"kid"`
+	CTR        uint64  `json:"ctr"`
+	Header     HexData `json:"header"`
+	Nonce      HexData `json:"nonce"`
+	Ciphertext HexData `json:"ciphertext"`
+}
+
+type TestVector struct {
+	CipherSuite CipherSuite  `json:"cipher_suite"`
+	BaseKey     HexData      `json:"base_key"`
+	Key         HexData      `json:"key"`
+	Salt        HexData      `json:"salt"`
+	Plaintext   HexData      `json:"plaintext"`
+	Encryptions []Encryption `json:"encryptions"`
+}
+
+///
+/// Test vector generation
+///
+type HeaderCase struct {
+	KID uint64
+	CTR uint64
+}
+
+type TestCase struct {
+	CipherSuite CipherSuite
+	BaseKey     []byte
+	Plaintext   []byte
+	HeaderCases []HeaderCase
+}
+
+func minBigEndian(val uint64) []byte {
+	max := make([]byte, 8)
+	binary.BigEndian.PutUint64(max, val)
+	for i, b := range max {
+		if b != 0 {
+			return max[i:]
+		}
+	}
+	return []byte{0}
+}
+
+func makeHeader(headerCase HeaderCase) []byte {
+	kidData := minBigEndian(headerCase.KID)
+	ctrData := minBigEndian(headerCase.CTR)
+
+	KLEN := byte(len(kidData))
+	LEN := byte(len(ctrData))
+	if LEN > 7 {
+		panic(fmt.Sprintf("CTR too long"))
+	}
+
+	config := LEN << 4
+	if headerCase.KID <= 7 {
+		config |= byte(headerCase.KID)
+		kidData = nil
+		KLEN = 0
+	} else {
+		config |= 0x08 | KLEN
+	}
+
+	header := make([]byte, 1+LEN+KLEN)
+	header[0] = config
+	copy(header[1:1+KLEN], kidData)
+	copy(header[1+KLEN:], ctrData)
+	return header
+}
+
+func encrypt(suite CipherSuite, headerCase HeaderCase, key, salt, plaintext []byte) Encryption {
+	header := makeHeader(headerCase)
+
+	nonce := make([]byte, suite.Nn)
+	binary.BigEndian.PutUint64(nonce[suite.Nn-8:], headerCase.CTR)
+	for i := range nonce {
+		nonce[i] ^= salt[i]
+	}
+
+	aead := suite.NewAEAD(key)
+	ct := aead.Seal(nil, nonce, plaintext, header)
+	ct = append(header, ct...)
+
+	return Encryption{
+		KID:        headerCase.KID,
+		CTR:        headerCase.CTR,
+		Header:     header,
+		Nonce:      nonce,
+		Ciphertext: ct,
+	}
+}
+
+func makeTestVector(tc TestCase) TestVector {
+	suite := tc.CipherSuite
+	secret := suite.Extract(tc.BaseKey, []byte("SFrame10"))
+	key := suite.Expand(secret, []byte("key"), suite.Nk)
+	salt := suite.Expand(secret, []byte("salt"), suite.Nn)
+
+	encryptions := make([]Encryption, len(tc.HeaderCases))
+	for i, hc := range tc.HeaderCases {
+		encryptions[i] = encrypt(suite, hc, key, salt, tc.Plaintext)
+	}
+
+	return TestVector{
+		CipherSuite: suite,
+		BaseKey:     tc.BaseKey,
+		Key:         key,
+		Salt:        salt,
+		Plaintext:   tc.Plaintext,
+		Encryptions: encryptions,
+	}
+}
+
+///
+/// main
+///
+
+func fromHex(h string) []byte {
+	b, _ := hex.DecodeString(h)
+	return b
+}
+
+func toHex(b []byte, width, indent int) string {
+	h := hex.EncodeToString(b)
+	pad := strings.Repeat(" ", indent)
+
+	if len(h) < width {
+		return h
+	}
+
+	out := h[:width] + "\n"
+	start := width
+	for start < len(h)-width {
+		out += pad + h[start:start+width] + "\n"
+		start += width
+	}
+
+	if start != len(h) {
+		out += pad + h[start:]
+	} else {
+		out = out[:len(out)-1]
+	}
+
+	return out
+}
+
+var (
+	hexWidth     = 32
+	hexIndent    = 16
+	testVectorMD = `## %s
+
+~~~
+CipherSuite:    0x%02x
+Base Key:       %s
+Key:            %s
+Salt:           %s
+Plaintext:      %s
+~~~
+`
+
+	encryptionMD = `
+~~~
+KID:            0x%x
+CTR:            0x%x
+Header:         %s
+Nonce:          %s
+Ciphertext:     %s
+~~~
+`
+)
+
+func renderMarkdown(tv TestVector) string {
+	cipherName := tv.CipherSuite.Name
+	cipherID := tv.CipherSuite.ID
+	baseKeyMD := toHex(tv.BaseKey, hexWidth, hexIndent)
+	keyMD := toHex(tv.Key, hexWidth, hexIndent)
+	saltMD := toHex(tv.Salt, hexWidth, hexIndent)
+	plaintextMD := toHex(tv.Plaintext, hexWidth, hexIndent)
+	out := fmt.Sprintf(testVectorMD, cipherName, cipherID, baseKeyMD, keyMD, saltMD, plaintextMD)
+
+	for _, enc := range tv.Encryptions {
+		headerMD := toHex(enc.Header, hexWidth, hexIndent)
+		nonceMD := toHex(enc.Nonce, hexWidth, hexIndent)
+		ciphertextMD := toHex(enc.Ciphertext, hexWidth, hexIndent)
+		out += fmt.Sprintf(encryptionMD, enc.KID, enc.CTR, headerMD, nonceMD, ciphertextMD)
+	}
+
+	return out
+}
+
+func main() {
+	// Test parameters
+	plaintext := []byte("From heavenly harmony // This universal frame began")
+
+	headerCases := []HeaderCase{
+		HeaderCase{KID: 0x07, CTR: 0x00},
+		HeaderCase{KID: 0x07, CTR: 0x01},
+		HeaderCase{KID: 0x07, CTR: 0x02},
+		HeaderCase{KID: 0x0f, CTR: 0xaa},
+		HeaderCase{KID: 0x01ff, CTR: 0xaa},
+		HeaderCase{KID: 0x01ff, CTR: 0xaaaa},
+		HeaderCase{KID: 0xffffffffffffff, CTR: 0xffffffffffffff},
+	}
+
+	testCases := []TestCase{
+		TestCase{
+			CipherSuite: AES_CM_128_HMAC_SHA256_4,
+			BaseKey:     fromHex("101112131415161718191a1b1c1d1e1f"),
+			Plaintext:   plaintext,
+			HeaderCases: headerCases,
+		},
+		TestCase{
+			CipherSuite: AES_CM_128_HMAC_SHA256_8,
+			BaseKey:     fromHex("202122232425262728292a2b2c2d2e2f"),
+			Plaintext:   plaintext,
+			HeaderCases: headerCases,
+		},
+		TestCase{
+			CipherSuite: AES_GCM_128_SHA256,
+			BaseKey:     fromHex("303132333435363738393a3b3c3d3e3f"),
+			Plaintext:   plaintext,
+			HeaderCases: headerCases,
+		},
+		TestCase{
+			CipherSuite: AES_GCM_256_SHA512,
+			BaseKey:     fromHex("404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f"),
+			Plaintext:   plaintext,
+			HeaderCases: headerCases,
+		},
+	}
+
+	// Command-line flags
+	var jsonFlag, mdFlag bool
+	flag.BoolVar(&jsonFlag, "json", false, "Output JSON")
+	flag.BoolVar(&mdFlag, "md", false, "Output Markdown")
+	flag.Parse()
+
+	if jsonFlag == mdFlag {
+		panic("Exactly one output format must be specified")
+	}
+
+	// Generate and render test vectors
+	testVectors := make([]TestVector, len(testCases))
+	for i, tc := range testCases {
+		testVectors[i] = makeTestVector(tc)
+	}
+
+	if jsonFlag {
+		jsonVectors, err := json.MarshalIndent(testVectors, "", "  ")
+		chk(err)
+		fmt.Println(string(jsonVectors))
+	}
+
+	if mdFlag {
+		for _, tv := range testVectors {
+			fmt.Println(renderMarkdown(tv))
+		}
+	}
+}


### PR DESCRIPTION
This PR adds test vectors for SFrame encryption.  A Go script is provided that implements the header encoding and the relevant encryption routines, generates test vectors for salient cases, and serializes them as Markdown or JSON.  The Markdown version is included in the specification directly.